### PR TITLE
fix: typo in useScreen composable

### DIFF
--- a/composables/useScreen.ts
+++ b/composables/useScreen.ts
@@ -41,7 +41,7 @@ export const useScreen = () => {
     return Size.EXTRA_LARGE
   }
 
-  const onWindowRezise = () => {
+  const onWindowResize = () => {
     const { innerWidth, innerHeight } = window
     screenSize.width = innerWidth
     screenSize.height = innerHeight
@@ -65,13 +65,13 @@ export const useScreen = () => {
 
   onMounted(() => {
     if (typeof window === 'undefined') return
-    window.addEventListener('resize', onWindowRezise)
+    window.addEventListener('resize', onWindowResize)
     getSize(window.innerWidth)
   })
 
   onUnmounted(() => {
     if (typeof window === 'undefined') return
-    window.removeEventListener('resize', onWindowRezise)
+    window.removeEventListener('resize', onWindowResize)
   })
 
   return {


### PR DESCRIPTION
I noticed a typo and fixed it in `composables/useScreen.ts`. The composable had `onWindowResize` declared as `onWindowRezise`.

ty