### PR TITLE
support some new feature

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -25,7 +25,7 @@ useHead({
 <template>
   <Html :class="`${theme === 'dark' ? 'dark' : ''}`" :lang="locale">
     <Body
-      class="antialiased duration-300 transition-colors text-gray-800 dark:text-gray-200 bg-white dark:bg-gray-900"
+      class="antialiased duration-300 transition-colors text-gray-800 dark:text-gray-200 bg-white dark:bg-gray-900 overscroll-y-none"
     >
       <NuxtLayout>
         <NuxtLoadingIndicator :height="5" :duration="3000" :throttle="400" />

--- a/components/DocumentDrivenNotFound.vue
+++ b/components/DocumentDrivenNotFound.vue
@@ -1,0 +1,9 @@
+<template>
+  <LayoutPage>
+    <Error :code="404" wrap />
+  </LayoutPage>
+</template>
+
+<script setup>
+import LayoutPage from '~/layouts/page.vue'
+</script>

--- a/components/Page/Content/Doc.vue
+++ b/components/Page/Content/Doc.vue
@@ -1,3 +1,13 @@
+<script setup>
+const props = defineProps({
+  emptyTip: {
+    type: String,
+    required: false,
+    default: 'This page is empty',
+  },
+})
+</script>
+
 <template>
   <ContentDoc>
     <template #default="{ doc }">
@@ -11,7 +21,7 @@
       </PageBody>
     </template>
     <template #empty>
-      <h1>Post in empty</h1>
+      <h1>{{ emptyTip }}</h1>
     </template>
     <template #not-found>
       <Error :code="404" wrap />

--- a/pages/post/[slug].vue
+++ b/pages/post/[slug].vue
@@ -6,6 +6,6 @@ definePageMeta({
 
 <template>
   <PageWrapper class="flex flex-col">
-    <PageContentDoc />
+    <PageContentDoc empty-tip="Post im empty" />
   </PageWrapper>
 </template>


### PR DESCRIPTION
# Style
- add `overscroll-y-none` on body classlist

# Feature
- other documents may use `PageContentDoc` Com but not belong to the post type， so it is more appropriate to provide a custom empty tip by `emptyTip`

- add `DocumentDrivenNotFound` Com to catch routes that don't exist，which should show 404 page