### PR TITLE
style: fix title color for Alert component

### DIFF
--- a/components/Alert.vue
+++ b/components/Alert.vue
@@ -33,7 +33,7 @@ const styles = reactive<{
 const textStyles = reactive<{
   [key: string]: string
 }>({
-  primary: 'text-white',
+  primary: 'text-black dark:text-white',
   success: 'text-green-500',
   warning: 'text-orange-500',
   danger: 'text-red-500',


### PR DESCRIPTION
The title color "primary" isn't good when we switch to the light theme.